### PR TITLE
Add clean command

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,33 @@
-from setuptools import find_packages, setup
+import glob
+import os
+import shutil
+
+from setuptools import Command, find_packages, setup
+
+class clean(Command):
+    user_options = []
+    CLEAN_DIRS = [
+        "./build",
+        "./dist",
+        *[dir for dir in glob.glob("./**/*.egg-info", recursive=True)],
+        *[dir for dir in glob.glob("./**/__pycache__", recursive=True)],
+    ]
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        for dir in self.CLEAN_DIRS:
+            dir = os.path.relpath(dir)
+            for path in glob.glob(os.path.join(dir, "**/*"), recursive=True):
+                print("removing", path)
+            for path in glob.glob(dir):
+                print("removing", path)
+            if os.path.exists(dir):
+                shutil.rmtree(dir)
 
 with open("requirements.txt", encoding="UTF-8") as f:
     requirements = f.read().split()
@@ -8,4 +37,5 @@ setup(
     install_requires = requirements,
     packages = find_packages(where="src"),
     package_dir = {"": "src"},
+    cmdclass = {"clean": clean},
 )


### PR DESCRIPTION
Add `clean` command to `setup.py` file. To invoke this command type `python setup.py clean`, this will remove every files and directories specified in the `clean.CLEAN_DIRS` list.